### PR TITLE
Implemented getting team points and overall leaderboard

### DIFF
--- a/team_leaderboard.py
+++ b/team_leaderboard.py
@@ -1,0 +1,34 @@
+from flask import Flask, jsonify
+from pymongo import MongoClient
+
+app = Flask(__name__)
+
+MONGO_URI = "mongodb+srv://mshteynberg:moosementcluster@moosement.lnn1d.mongodb.net/"
+client = MongoClient(MONGO_URI)
+db = client["moosement"]
+teams_collection = db["team_data"]
+
+# Called when fetching the leaderboard to update each team's ranking based off of their current number of points
+def update_leaderboard():
+    # Lists all the teams but sorted in descending order by their number of team points
+    teams = list(teams_collection.find({}, {"_id": 0, "team_id": 1, "total_team_points": 1}).sort("total_team_points", DESCENDING))
+
+    # Iterates through all the teams setting a rank for them
+    for index, team in enumerate(teams):
+        rank = index + 1
+        teams_collection.update_one(
+            {"team_id": team["team_id"]},
+            {"$set": {"team_standing": rank}}
+        )
+
+# API route to update the leaderboard based off of the current points each team has
+@app.get("/api/team/leaderboard")
+def get_leaderboard():
+    update_leaderboard()
+    # Sorts the teams by their now updated standing to output as a list repreenting the leaderboard
+    leaderboard = list(teams_collection.find({}, {"_id": 0, "team_id": 1, "total_team_points": 1, "team_standing": 1}).sort("team_standing", 1))
+    
+    return jsonify({"leaderboard": leaderboard})
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/team_points.py
+++ b/team_points.py
@@ -1,0 +1,35 @@
+from flask import Flask, jsonify
+from pymongo import MongoClient
+
+app = Flask(__name__)
+
+MONGO_URI = "mongodb+srv://mshteynberg:moosementcluster@moosement.lnn1d.mongodb.net/"
+client = MongoClient(MONGO_URI)
+db = client["moosement"]
+teams_collection = db["team_data"]
+
+# API route to get the number of total points for a team
+@app.route("/api/team/points", methods=["GET"])
+def get_team_points():
+    data = request.get_json()
+
+    # check that a team_id to get standings for was received
+    if "team_id" not in data:
+            return jsonify({"error": f"Missing field: team_id"}), 400
+    
+    team_id = data["team_id"]
+
+    team = teams_collection.find_one({"team_id": team_id})
+    # if no team exists with that id, return an error
+    if not team:
+        return jsonify({"error": "Invalid team"}), 400
+
+    return jsonify({
+        "team_id": team_id,
+        "team_total_points": team["total_team_points"]
+    }), 200
+
+if __name__ == "__main__":
+    app.run(debug=True)
+
+


### PR DESCRIPTION
- Added `team_points.py` which provides a GET endpoint to be able to get the points of a team based on their team_id
- Added `team_leaderboard.py` which contains:
  -  A helper function `update_leaderboard()` which updates the `standing` of a team based off of how many points they currently have as stored in the team_data collection in the database
  - The `get_leaderboard()` function which serves as the GET endpoint that first calls the helper function to update the standings of each team and will return the sorted list of teams based off of their standings. 